### PR TITLE
Use latest document bundle version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.palladiosimulator</groupId>
 	<artifactId>eclipse-parent</artifactId>	
-	<version>0.1.9</version>
+	<version>0.1.10-SNAPSHOT</version>
 
 	<name>Palladio Maven Tycho Parent</name>
 	<description>A common parent POM for Maven Tycho based builds of Palladio related Eclipse extensions.</description>
@@ -387,7 +387,7 @@
 						<plugin>
 							<groupId>org.palladiosimulator</groupId>
 							<artifactId>tycho-document-bundle-plugin</artifactId>
-							<version>1.1.1</version>
+							<version>1.1.2</version>
 							<executions>
 								<execution>
 									<id>eclipse-javadoc</id>


### PR DESCRIPTION
The new version of the parent POM includes the latest version of the documentation bundle to make use of included bug fixes.