### PR TITLE
Use target platform including EPL2 license

### DIFF
--- a/product/pom.xml
+++ b/product/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>org.palladiosimulator</groupId>
 	<artifactId>eclipse-parent-product</artifactId>
-	<version>0.1.1</version>
+	<version>0.1.2-SNAPSHOT</version>
 	<name>${project.artifactId}</name>
 	<description>A common parent POM for all Eclipse product builds of Palladio.</description>
 	<url>http://palladiosimulator.org</url>

--- a/product/pom.xml
+++ b/product/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>org.palladiosimulator</groupId>
 	<artifactId>eclipse-parent-product</artifactId>
-	<version>0.1.1-SNAPSHOT</version>
+	<version>0.1.1</version>
 	<name>${project.artifactId}</name>
 	<description>A common parent POM for all Eclipse product builds of Palladio.</description>
 	<url>http://palladiosimulator.org</url>

--- a/updatesite/pom.xml
+++ b/updatesite/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>org.palladiosimulator</groupId>
 	<artifactId>eclipse-parent-updatesite</artifactId>
-	<version>0.1.1-SNAPSHOT</version>
+	<version>0.1.1</version>
 	<name>${project.artifactId}</name>
 	<description>A common parent POM for all Eclipse Update Site builds of Palladio.</description>
 	<url>http://palladiosimulator.org</url>

--- a/updatesite/pom.xml
+++ b/updatesite/pom.xml
@@ -64,7 +64,8 @@
 				</file>
 			</activation>
 			<properties>
-				<org.palladiosimulator.maven.tychotprefresh.tplocation.1>org.palladiosimulator:target-platform-base:0.1.3-SNAPSHOT:license-1:target</org.palladiosimulator.maven.tychotprefresh.tplocation.1>
+				<org.palladiosimulator.maven.tychotprefresh.tplocation.0>tools.mdsd:eclipse-target-platforms:0.1.0:eclipse-modeling-oxygen-3:target</org.palladiosimulator.maven.tychotprefresh.tplocation.0>
+				<org.palladiosimulator.maven.tychotprefresh.tplocation.1>org.palladiosimulator:target-platform-base:0.1.4:license-2:target</org.palladiosimulator.maven.tychotprefresh.tplocation.1>
 			</properties>
 			<build>
 				<pluginManagement>

--- a/updatesite/pom.xml
+++ b/updatesite/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>org.palladiosimulator</groupId>
 	<artifactId>eclipse-parent-updatesite</artifactId>
-	<version>0.1.1</version>
+	<version>0.1.2-SNAPSHOT</version>
 	<name>${project.artifactId}</name>
 	<description>A common parent POM for all Eclipse Update Site builds of Palladio.</description>
 	<url>http://palladiosimulator.org</url>


### PR DESCRIPTION
The previous release 0.1.0 referred to a snapshot version of the target platform containing the Palladio EPL licenses. I switched to the correct release version of the artefact containing the target platform and used the target platform containing the EPL 2 feature.