### PR TITLE
Use latest license target platform definition.

### DIFF
--- a/updatesite/pom.xml
+++ b/updatesite/pom.xml
@@ -28,7 +28,7 @@
 			</activation>
 			<properties>
 				<org.palladiosimulator.maven.tychotprefresh.tplocation.0>tools.mdsd:eclipse-target-platforms:0.1.2:eclipse-modeling-oxygen-3:target</org.palladiosimulator.maven.tychotprefresh.tplocation.0>
-				<org.palladiosimulator.maven.tychotprefresh.tplocation.1>org.palladiosimulator:target-platform-base:0.1.4:license-2:target</org.palladiosimulator.maven.tychotprefresh.tplocation.1>
+				<org.palladiosimulator.maven.tychotprefresh.tplocation.1>org.palladiosimulator:target-platform-base:0.1.5:license:target</org.palladiosimulator.maven.tychotprefresh.tplocation.1>
 			</properties>
 			<build>
 				<pluginManagement>


### PR DESCRIPTION
This PR suggests using the latest target platform definition of the license features. It will only work after the sync of the new target platform artifact to Maven Central took place.