### PR TITLE
Incremented parent version to 0.6.0

### DIFF
--- a/product/pom.xml
+++ b/product/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<groupId>tools.mdsd</groupId>
 		<artifactId>eclipse-parent-product</artifactId>
-		<version>0.5.1</version>
+		<version>0.6.0</version>
 		<relativePath/>
 	</parent>
 	<groupId>org.palladiosimulator</groupId>
 	<artifactId>eclipse-parent-product</artifactId>
-	<version>0.5.2-SNAPSHOT</version>
+	<version>0.6.0-SNAPSHOT</version>
 	<name>${project.artifactId}</name>
 	<description>A common parent POM for all Eclipse product builds of Palladio.</description>
 	<url>http://palladiosimulator.org</url>

--- a/updatesite-notp/pom.xml
+++ b/updatesite-notp/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<groupId>tools.mdsd</groupId>
 		<artifactId>eclipse-parent-updatesite-notp</artifactId>
-		<version>0.5.1</version>
+		<version>0.6.0</version>
 		<relativePath/>
 	</parent>
 	<groupId>org.palladiosimulator</groupId>
 	<artifactId>eclipse-parent-updatesite-notp</artifactId>
-	<version>0.5.2-SNAPSHOT</version>
+	<version>0.6.0-SNAPSHOT</version>
 	<name>${project.artifactId}</name>
 	<description>A common parent POM for all Eclipse Update Site builds of Palladio.</description>
 	<url>http://palladiosimulator.org</url>

--- a/updatesite/pom.xml
+++ b/updatesite/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<groupId>tools.mdsd</groupId>
 		<artifactId>eclipse-parent-updatesite</artifactId>
-		<version>0.5.1</version>
+		<version>0.6.0</version>
 		<relativePath/>
 	</parent>
 	<groupId>org.palladiosimulator</groupId>
 	<artifactId>eclipse-parent-updatesite</artifactId>
-	<version>0.5.2-SNAPSHOT</version>
+	<version>0.6.0-SNAPSHOT</version>
 	<name>${project.artifactId}</name>
 	<description>A common parent POM for all Eclipse Update Site builds of Palladio.</description>
 	<url>http://palladiosimulator.org</url>


### PR DESCRIPTION
Incremented MDSD.tools eclipse parent versions. As the parent contains a potentially breaking change, the version number was incremented to 0.6.0-SNAPSHOT. The PR should be merged once 0.6.0 was released via Sonatype.