### PR TITLE
Support for snapshot dependencies in nightly build

### DIFF
--- a/product/pom.xml
+++ b/product/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.mdsd</groupId>
 		<artifactId>eclipse-parent-product</artifactId>
-		<version>0.7.1</version>
+		<version>0.7.2-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 	<groupId>org.palladiosimulator</groupId>
@@ -16,5 +16,30 @@
 	<description>A common parent POM for all Eclipse product builds of Palladio.</description>
 	<url>http://palladiosimulator.org</url>
 	<packaging>pom</packaging>
+	
+	<profiles>
+		<profile>
+			<id>nightly-dependencies</id>
+			<activation>
+				<property>
+					<name>!release</name>
+				</property>
+			</activation>
+			<repositories>
+				<repository>
+					<id>central</id>
+					<url>https://repo.maven.apache.org/maven2/</url>
+				</repository>
+				<repository>
+					<id>sonatype-staging</id>
+					<url>https://oss.sonatype.org/content/groups/staging/</url>
+				</repository>
+				<repository>
+					<id>sonatype-snapshots</id>
+					<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+				</repository>
+			</repositories>
+		</profile>
+	</profiles>
 
 </project>

--- a/updatesite-notp/pom.xml
+++ b/updatesite-notp/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.mdsd</groupId>
 		<artifactId>eclipse-parent-updatesite-notp</artifactId>
-		<version>0.7.1</version>
+		<version>0.7.2-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 	<groupId>org.palladiosimulator</groupId>
@@ -18,6 +18,28 @@
 	<packaging>pom</packaging>
 
 	<profiles>
+		<profile>
+			<id>nightly-dependencies</id>
+			<activation>
+				<property>
+					<name>!release</name>
+				</property>
+			</activation>
+			<repositories>
+				<repository>
+					<id>central</id>
+					<url>https://repo.maven.apache.org/maven2/</url>
+				</repository>
+				<repository>
+					<id>sonatype-staging</id>
+					<url>https://oss.sonatype.org/content/groups/staging/</url>
+				</repository>
+				<repository>
+					<id>sonatype-snapshots</id>
+					<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+				</repository>
+			</repositories>
+		</profile>
 
 		<profile>
 			<id>palladio-build-customizations</id>

--- a/updatesite/pom.xml
+++ b/updatesite/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.mdsd</groupId>
 		<artifactId>eclipse-parent-updatesite</artifactId>
-		<version>0.7.1</version>
+		<version>0.7.2-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 	<groupId>org.palladiosimulator</groupId>
@@ -18,6 +18,28 @@
 	<packaging>pom</packaging>
 
 	<profiles>
+		<profile>
+			<id>nightly-dependencies</id>
+			<activation>
+				<property>
+					<name>!release</name>
+				</property>
+			</activation>
+			<repositories>
+				<repository>
+					<id>central</id>
+					<url>https://repo.maven.apache.org/maven2/</url>
+				</repository>
+				<repository>
+					<id>sonatype-staging</id>
+					<url>https://oss.sonatype.org/content/groups/staging/</url>
+				</repository>
+				<repository>
+					<id>sonatype-snapshots</id>
+					<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+				</repository>
+			</repositories>
+		</profile>
 
 		<profile>
 			<id>palladio-build-customizations</id>


### PR DESCRIPTION
Allow for nighly versions to resolve dependencies (i. e. the parent) via snapshot repositories.