### PR TITLE
Fix wrong policy

### DIFF
--- a/product/pom.xml
+++ b/product/pom.xml
@@ -33,7 +33,7 @@
 						<enabled>false</enabled>
 					</releases>
 					<snapshots>
-						<updatePolicy>never</updatePolicy>
+						<updatePolicy>always</updatePolicy>
 					</snapshots>
 				</repository>
 			</repositories>

--- a/updatesite-notp/pom.xml
+++ b/updatesite-notp/pom.xml
@@ -33,7 +33,7 @@
 						<enabled>false</enabled>
 					</releases>
 					<snapshots>
-						<updatePolicy>never</updatePolicy>
+						<updatePolicy>always</updatePolicy>
 					</snapshots>
 				</repository>
 			</repositories>

--- a/updatesite/pom.xml
+++ b/updatesite/pom.xml
@@ -33,7 +33,7 @@
 						<enabled>false</enabled>
 					</releases>
 					<snapshots>
-						<updatePolicy>never</updatePolicy>
+						<updatePolicy>always</updatePolicy>
 					</snapshots>
 				</repository>
 			</repositories>


### PR DESCRIPTION
The previous PR contained a wrong update policy specification for snapshot dependencies.