### PR TITLE
Bump version to 0.9.0-SNAPSHOT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on: [workflow_dispatch]
 
 jobs:
   release:
-    name: Release on Sonatype OSS
+    name: Release on Sonatype Central
     runs-on: ubuntu-latest
 
     steps:
@@ -24,15 +24,15 @@ jobs:
         with: # running setup-java again overwrites the settings.xml
           java-version: 17
           distribution: 'zulu'
-          server-id: ossrh
-          server-username: OSSRH_USERNAME
-          server-password: OSSRH_PASSWORD
+          server-id: central
+          server-username: CENTRAL_USERNAME
+          server-password: CENTRAL_PASSWORD
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
       - name: Publish to Apache Maven Central
         run: mvn -Plocal-build-deployable deploy
         env:
-          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2.5.0
+      - uses: actions/checkout@v4.2.2
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3.6.0
+        uses: actions/setup-java@v4.7.1
         with:
           distribution: 'zulu'
           java-version: 17
@@ -20,7 +20,7 @@ jobs:
         run: mvn -B package --file pom.xml
 
       - name: Set up Apache Maven Central
-        uses: actions/setup-java@v3.6.0
+        uses: actions/setup-java@v4.7.1
         with: # running setup-java again overwrites the settings.xml
           java-version: 17
           distribution: 'zulu'

--- a/eclipse/pom.xml
+++ b/eclipse/pom.xml
@@ -74,7 +74,6 @@
 				<configuration>
 					<publishingServerId>central</publishingServerId>
 					<centralBaseUrl>https://central.sonatype.com</centralBaseUrl>
-					<centralSnapshotsUrl>https://central.sonatype.com/repository/maven-snapshots/</centralSnapshotsUrl>
 					<autoPublish>true</autoPublish>
 					<waitUntil>published</waitUntil>
 				</configuration>

--- a/eclipse/pom.xml
+++ b/eclipse/pom.xml
@@ -69,7 +69,7 @@
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.13</version>
+				<version>1.7.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<serverId>ossrh</serverId>
@@ -101,7 +101,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
-						<version>1.6</version>
+						<version>3.2.7</version>
 						<executions>
 							<execution>
 								<id>sign-artifacts</id>
@@ -315,7 +315,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-jar-plugin</artifactId>
-						<version>3.2.0</version>
+						<version>3.4.2</version>
 						<executions>
 							<execution>
 								<id>artifact-javadoc-package</id>
@@ -374,7 +374,7 @@
 						<plugin>
 							<groupId>org.apache.maven.plugins</groupId>
 							<artifactId>maven-compiler-plugin</artifactId>
-							<version>3.8.1</version>
+							<version>3.14.0</version>
 						</plugin>
 
 						<plugin>
@@ -415,7 +415,7 @@
 						<plugin>
 							<groupId>org.eclipse.xtend</groupId>
 							<artifactId>xtend-maven-plugin</artifactId>
-							<version>2.29.0</version>
+							<version>2.39.0</version>
 							<executions>
 								<execution>
 									<goals>
@@ -432,7 +432,7 @@
 						<plugin>
 							<groupId>org.apache.maven.plugins</groupId>
 							<artifactId>maven-clean-plugin</artifactId>
-							<version>3.2.0</version>
+							<version>3.5.0</version>
 							<configuration>
 								<excludeDefaultDirectories>true</excludeDefaultDirectories>
 								<filesets>
@@ -461,7 +461,7 @@
 						<plugin>
 							<groupId>org.jacoco</groupId>
 							<artifactId>jacoco-maven-plugin</artifactId>
-							<version>0.8.8</version>
+							<version>0.8.13</version>
 							<executions>
 								<execution>
 									<id>jacoco-prepare</id>
@@ -502,7 +502,7 @@
 					<plugin>
 						<groupId>org.codehaus.mojo</groupId>
 						<artifactId>exec-maven-plugin</artifactId>
-						<version>3.1.0</version>
+						<version>3.5.1</version>
 						<executions>
 							<execution>
 								<id>ExecuteMWE2LauncherForGenerate</id>
@@ -539,7 +539,7 @@
 					<plugin>
 						<groupId>org.codehaus.mojo</groupId>
 						<artifactId>exec-maven-plugin</artifactId>
-						<version>3.1.0</version>
+						<version>3.5.1</version>
 						<executions>
 							<execution>
 								<id>ExecuteMWE2LauncherForClean</id>
@@ -729,7 +729,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-compiler-plugin</artifactId>
-						<version>3.10.1</version>
+						<version>3.14.0</version>
 						<executions>
 							<execution>
 								<id>process-dagger-annotations</id>
@@ -754,7 +754,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-clean-plugin</artifactId>
-						<version>3.2.0</version>
+						<version>3.5.0</version>
 						<executions>
 							<execution>
 								<id>clean-src-gen</id>

--- a/eclipse/pom.xml
+++ b/eclipse/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.palladiosimulator</groupId>
 	<artifactId>eclipse-parent</artifactId>
-	<version>0.8.11-SNAPSHOT</version>
+	<version>0.9.0-SNAPSHOT</version>
 	<name>${project.artifactId}</name>
 	<description>A common parent POM for all Eclipse builds of Palladio.</description>
 	<url>http://palladiosimulator.org</url>

--- a/eclipse/pom.xml
+++ b/eclipse/pom.xml
@@ -67,14 +67,16 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.sonatype.plugins</groupId>
-				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.7.0</version>
+				<groupId>org.sonatype.central</groupId>
+				<artifactId>central-publishing-maven-plugin</artifactId>
+				<version>0.7.0</version>
 				<extensions>true</extensions>
 				<configuration>
-					<serverId>ossrh</serverId>
-					<nexusUrl>https://oss.sonatype.org/</nexusUrl>
-					<autoReleaseAfterClose>true</autoReleaseAfterClose>
+					<publishingServerId>central</publishingServerId>
+					<centralBaseUrl>https://central.sonatype.com</centralBaseUrl>
+					<centralSnapshotsUrl>https://central.sonatype.com/repository/maven-snapshots/</centralSnapshotsUrl>
+					<autoPublish>true</autoPublish>
+					<waitUntil>published</waitUntil>
 				</configuration>
 			</plugin>
 		</plugins>
@@ -86,16 +88,6 @@
 		<profile>
 			<id>local-build-deployable</id>
 			<!-- activate this profile explicitly by adding -Plocal-build-deployable to the maven command -->
-			<distributionManagement>
-				<snapshotRepository>
-					<id>ossrh</id>
-					<url>https://oss.sonatype.org/content/repositories/snapshots</url>
-				</snapshotRepository>
-				<repository>
-					<id>ossrh</id>
-					<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-				</repository>
-			</distributionManagement>
 			<build>
 				<plugins>
 					<plugin>

--- a/eclipse/pom.xml
+++ b/eclipse/pom.xml
@@ -101,14 +101,14 @@
 								<goals>
 									<goal>sign</goal>
 								</goals>
+								<configuration>
+									<gpgArguments>
+										<arg>--pinentry-mode</arg>
+										<arg>loopback</arg>
+									</gpgArguments>
+								</configuration>
 							</execution>
 						</executions>
-						<configuration>
-							<gpgArguments>
-								<arg>--pinentry-mode</arg>
-								<arg>loopback</arg>
-							</gpgArguments>
-						</configuration>
 					</plugin>
 				</plugins>
 			</build>
@@ -128,24 +128,43 @@
 				<updatesite.aggregator.filename>target/classes/nightly.aggr</updatesite.aggregator.filename>
 			</properties>
 
-			<pluginRepositories>
-				<pluginRepository>
-					<id>sonatype-snapshots</id>
-					<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+			<repositories>
+				<repository>
+					<name>Central Portal Snapshots</name>
+					<id>central-portal-snapshots</id>
+					<url>https://central.sonatype.com/repository/maven-snapshots/</url>
 					<releases>
 						<enabled>false</enabled>
 					</releases>
 					<snapshots>
+						<enabled>true</enabled>
+						<updatePolicy>always</updatePolicy>
+					</snapshots>
+				</repository>
+			</repositories>
+
+			<pluginRepositories>
+				<pluginRepository>
+					<name>Central Portal Snapshots</name>
+					<id>central-portal-snapshots</id>
+					<url>https://central.sonatype.com/repository/maven-snapshots/</url>
+					<releases>
+						<enabled>false</enabled>
+					</releases>
+					<snapshots>
+						<enabled>true</enabled>
 						<updatePolicy>always</updatePolicy>
 					</snapshots>
 				 </pluginRepository>
 				 <pluginRepository>
+				 	<name>Tycho Snapshots</name>
 					<id>tycho-snapshots</id>
 					<url>https://repo.eclipse.org/content/repositories/tycho-snapshots/</url>
 					<releases>
 						<enabled>false</enabled>
 					</releases>
 					<snapshots>
+						<enabled>true</enabled>
 						<updatePolicy>always</updatePolicy>
 					</snapshots>
 				 </pluginRepository>
@@ -363,6 +382,41 @@
 			<build>
 				<pluginManagement>
 					<plugins>
+						<plugin>
+							<groupId>org.eclipse.tycho</groupId>
+							<artifactId>target-platform-configuration</artifactId>
+							<version>${tycho.version}</version>
+							<configuration>
+								<environments>
+									<environment>
+										<os>linux</os>
+										<ws>gtk</ws>
+										<arch>x86_64</arch>
+									</environment>
+									<environment>
+										<os>linux</os>
+										<ws>gtk</ws>
+										<arch>aarch64</arch>
+									</environment>
+									<environment>
+										<os>win32</os>
+										<ws>win32</ws>
+										<arch>x86_64</arch>
+									</environment>
+									<environment>
+										<os>macosx</os>
+										<ws>cocoa</ws>
+										<arch>x86_64</arch>
+									</environment>
+									<environment>
+										<os>macosx</os>
+										<ws>cocoa</ws>
+										<arch>aarch64</arch>
+									</environment>
+								</environments>
+							</configuration>
+						</plugin>
+
 						<plugin>
 							<groupId>org.apache.maven.plugins</groupId>
 							<artifactId>maven-compiler-plugin</artifactId>

--- a/eclipse/product/pom.xml
+++ b/eclipse/product/pom.xml
@@ -32,40 +32,6 @@
 				<pluginManagement>
 					<plugins>
 						<plugin>
-							<groupId>org.eclipse.tycho</groupId>
-							<artifactId>target-platform-configuration</artifactId>
-							<version>${tycho.version}</version>
-							<configuration>
-								<environments>
-									<environment>
-										<os>linux</os>
-										<ws>gtk</ws>
-										<arch>x86_64</arch>
-									</environment>
-									<environment>
-										<os>linux</os>
-										<ws>gtk</ws>
-										<arch>aarch64</arch>
-									</environment>
-									<environment>
-										<os>win32</os>
-										<ws>win32</ws>
-										<arch>x86_64</arch>
-									</environment>
-									<environment>
-										<os>macosx</os>
-										<ws>cocoa</ws>
-										<arch>x86_64</arch>
-									</environment>
-									<environment>
-										<os>macosx</os>
-										<ws>cocoa</ws>
-										<arch>aarch64</arch>
-									</environment>
-								</environments>
-							</configuration>
-						</plugin>
-						<plugin>
 							<groupId>org.palladiosimulator</groupId>
 							<artifactId>tycho-tp-refresh-maven-plugin</artifactId>
 							<version>${org.palladiosimulator.maven.tychotprefresh.version}</version>
@@ -106,28 +72,6 @@
 			</build>
 		</profile>
 
-		<profile>
-			<id>nightly-dependencies</id>
-			<activation>
-				<property>
-					<name>!release</name>
-				</property>
-			</activation>
-			<repositories>
-				<repository>
-					<name>Central Portal Snapshots</name>
-					<id>central-portal-snapshots</id>
-					<url>https://central.sonatype.com/repository/maven-snapshots/</url>
-					<releases>
-						<enabled>false</enabled>
-					</releases>
-					<snapshots>
-						<enabled>true</enabled>
-						<updatePolicy>always</updatePolicy>
-					</snapshots>
-				</repository>
-			</repositories>
-		</profile>
 	</profiles>
 
 </project>

--- a/eclipse/product/pom.xml
+++ b/eclipse/product/pom.xml
@@ -115,12 +115,14 @@
 			</activation>
 			<repositories>
 				<repository>
-					<id>sonatype-snapshots</id>
-					<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+					<name>Central Portal Snapshots</name>
+					<id>central-portal-snapshots</id>
+					<url>https://central.sonatype.com/repository/maven-snapshots/</url>
 					<releases>
 						<enabled>false</enabled>
 					</releases>
 					<snapshots>
+						<enabled>true</enabled>
 						<updatePolicy>always</updatePolicy>
 					</snapshots>
 				</repository>

--- a/eclipse/product/pom.xml
+++ b/eclipse/product/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<groupId>org.palladiosimulator</groupId>
 		<artifactId>eclipse-parent</artifactId>
-		<version>0.8.11-SNAPSHOT</version>
+		<version>0.9.0-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 	<groupId>org.palladiosimulator</groupId>
 	<artifactId>eclipse-parent-product</artifactId>
-	<version>0.8.11-SNAPSHOT</version>
+	<version>0.9.0-SNAPSHOT</version>
 	<name>${project.artifactId}</name>
 	<description>A common parent POM for all Eclipse product builds of Palladio.</description>
 	<url>http://palladiosimulator.org</url>

--- a/eclipse/product/pom.xml
+++ b/eclipse/product/pom.xml
@@ -11,7 +11,6 @@
 	</parent>
 	<groupId>org.palladiosimulator</groupId>
 	<artifactId>eclipse-parent-product</artifactId>
-	<version>0.9.0-SNAPSHOT</version>
 	<name>${project.artifactId}</name>
 	<description>A common parent POM for all Eclipse product builds of Palladio.</description>
 	<url>http://palladiosimulator.org</url>

--- a/eclipse/updatesite-notp/pom.xml
+++ b/eclipse/updatesite-notp/pom.xml
@@ -11,7 +11,6 @@
 	</parent>
 	<groupId>org.palladiosimulator</groupId>
 	<artifactId>eclipse-parent-updatesite-notp</artifactId>
-	<version>0.9.0-SNAPSHOT</version>
 	<name>${project.artifactId}</name>
 	<description>A common parent POM for all Eclipse Update Site builds of Palladio.</description>
 	<url>http://palladiosimulator.org</url>

--- a/eclipse/updatesite-notp/pom.xml
+++ b/eclipse/updatesite-notp/pom.xml
@@ -32,40 +32,6 @@
 				<pluginManagement>
 					<plugins>
 						<plugin>
-							<groupId>org.eclipse.tycho</groupId>
-							<artifactId>target-platform-configuration</artifactId>
-							<version>${tycho.version}</version>
-							<configuration>
-								<environments>
-									<environment>
-										<os>linux</os>
-										<ws>gtk</ws>
-										<arch>x86_64</arch>
-									</environment>
-									<environment>
-										<os>linux</os>
-										<ws>gtk</ws>
-										<arch>aarch64</arch>
-									</environment>
-									<environment>
-										<os>win32</os>
-										<ws>win32</ws>
-										<arch>x86_64</arch>
-									</environment>
-									<environment>
-										<os>macosx</os>
-										<ws>cocoa</ws>
-										<arch>x86_64</arch>
-									</environment>
-									<environment>
-										<os>macosx</os>
-										<ws>cocoa</ws>
-										<arch>aarch64</arch>
-									</environment>
-								</environments>
-							</configuration>
-						</plugin>
-						<plugin>
 							<groupId>org.palladiosimulator</groupId>
 							<artifactId>tycho-tp-refresh-maven-plugin</artifactId>
 							<version>${org.palladiosimulator.maven.tychotprefresh.version}</version>
@@ -73,29 +39,6 @@
 					</plugins>
 				</pluginManagement>
 			</build>
-		</profile>
-
-		<profile>
-			<id>nightly-dependencies</id>
-			<activation>
-				<property>
-					<name>!release</name>
-				</property>
-			</activation>
-			<repositories>
-				<repository>
-					<name>Central Portal Snapshots</name>
-					<id>central-portal-snapshots</id>
-					<url>https://central.sonatype.com/repository/maven-snapshots/</url>
-					<releases>
-						<enabled>false</enabled>
-					</releases>
-					<snapshots>
-						<enabled>true</enabled>
-						<updatePolicy>always</updatePolicy>
-					</snapshots>
-				</repository>
-			</repositories>
 		</profile>
 
 		<profile>

--- a/eclipse/updatesite-notp/pom.xml
+++ b/eclipse/updatesite-notp/pom.xml
@@ -84,12 +84,14 @@
 			</activation>
 			<repositories>
 				<repository>
-					<id>sonatype-snapshots</id>
-					<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+					<name>Central Portal Snapshots</name>
+					<id>central-portal-snapshots</id>
+					<url>https://central.sonatype.com/repository/maven-snapshots/</url>
 					<releases>
 						<enabled>false</enabled>
 					</releases>
 					<snapshots>
+						<enabled>true</enabled>
 						<updatePolicy>always</updatePolicy>
 					</snapshots>
 				</repository>

--- a/eclipse/updatesite-notp/pom.xml
+++ b/eclipse/updatesite-notp/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<groupId>org.palladiosimulator</groupId>
 		<artifactId>eclipse-parent</artifactId>
-		<version>0.8.11-SNAPSHOT</version>
+		<version>0.9.0-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 	<groupId>org.palladiosimulator</groupId>
 	<artifactId>eclipse-parent-updatesite-notp</artifactId>
-	<version>0.8.11-SNAPSHOT</version>
+	<version>0.9.0-SNAPSHOT</version>
 	<name>${project.artifactId}</name>
 	<description>A common parent POM for all Eclipse Update Site builds of Palladio.</description>
 	<url>http://palladiosimulator.org</url>

--- a/eclipse/updatesite-notp/pom.xml
+++ b/eclipse/updatesite-notp/pom.xml
@@ -112,7 +112,7 @@
 						<plugin>
 							<groupId>org.apache.maven.plugins</groupId>
 							<artifactId>maven-checkstyle-plugin</artifactId>
-							<version>3.1.2</version>
+							<version>3.6.0</version>
 							<dependencies>
 								<dependency>
 									<groupId>com.puppycrawl.tools</groupId>

--- a/eclipse/updatesite/pom.xml
+++ b/eclipse/updatesite/pom.xml
@@ -116,12 +116,14 @@
 			</activation>
 			<repositories>
 				<repository>
-					<id>sonatype-snapshots</id>
-					<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+					<name>Central Portal Snapshots</name>
+					<id>central-portal-snapshots</id>
+					<url>https://central.sonatype.com/repository/maven-snapshots/</url>
 					<releases>
 						<enabled>false</enabled>
 					</releases>
 					<snapshots>
+						<enabled>true</enabled>
 						<updatePolicy>always</updatePolicy>
 					</snapshots>
 				</repository>

--- a/eclipse/updatesite/pom.xml
+++ b/eclipse/updatesite/pom.xml
@@ -11,7 +11,6 @@
 	</parent>
 	<groupId>org.palladiosimulator</groupId>
 	<artifactId>eclipse-parent-updatesite</artifactId>
-	<version>0.9.0-SNAPSHOT</version>
 	<name>${project.artifactId}</name>
 	<description>A common parent POM for all Eclipse Update Site builds of Palladio.</description>
 	<url>http://palladiosimulator.org</url>

--- a/eclipse/updatesite/pom.xml
+++ b/eclipse/updatesite/pom.xml
@@ -26,7 +26,7 @@
 				</file>
 			</activation>
 			<properties>
-				<org.palladiosimulator.maven.tychotprefresh.tplocation.0>tools.mdsd:eclipse-target-platforms:0.3.9:eclipse-modeling-2023-09:target</org.palladiosimulator.maven.tychotprefresh.tplocation.0>
+				<org.palladiosimulator.maven.tychotprefresh.tplocation.0>tools.mdsd:eclipse-target-platforms:0.3.9:eclipse-modeling-2023-03:target</org.palladiosimulator.maven.tychotprefresh.tplocation.0>
 				<org.palladiosimulator.maven.tychotprefresh.tpproject.groupId>${project.groupId}</org.palladiosimulator.maven.tychotprefresh.tpproject.groupId>
 				<org.palladiosimulator.maven.tychotprefresh.tpproject.artifactId>target-platform-merged-temporary</org.palladiosimulator.maven.tychotprefresh.tpproject.artifactId>
 				<org.palladiosimulator.maven.tychotprefresh.tpproject.version>1.0.0</org.palladiosimulator.maven.tychotprefresh.tpproject.version>

--- a/eclipse/updatesite/pom.xml
+++ b/eclipse/updatesite/pom.xml
@@ -39,7 +39,6 @@
 						<plugin>
 							<groupId>org.eclipse.tycho</groupId>
 							<artifactId>target-platform-configuration</artifactId>
-							<version>${tycho.version}</version>
 							<configuration>
 								<target>
 									<artifact>
@@ -49,33 +48,6 @@
 										<classifier>${org.palladiosimulator.maven.tychotprefresh.tpproject.classifier}</classifier> 
 									</artifact>
 								</target>
-								<environments>
-									<environment>
-										<os>linux</os>
-										<ws>gtk</ws>
-										<arch>x86_64</arch>
-									</environment>
-									<environment>
-										<os>linux</os>
-										<ws>gtk</ws>
-										<arch>aarch64</arch>
-									</environment>
-									<environment>
-										<os>win32</os>
-										<ws>win32</ws>
-										<arch>x86_64</arch>
-									</environment>
-									<environment>
-										<os>macosx</os>
-										<ws>cocoa</ws>
-										<arch>x86_64</arch>
-									</environment>
-									<environment>
-										<os>macosx</os>
-										<ws>cocoa</ws>
-										<arch>aarch64</arch>
-									</environment>
-								</environments>
 								<!-- fixes test execution on Java 11 -->
 								<!-- https://bugs.eclipse.org/bugs/show_bug.cgi?id=541403 -->
 								<dependency-resolution>
@@ -105,29 +77,6 @@
 					</plugins>
 				</pluginManagement>
 			</build>
-		</profile>
-
-		<profile>
-			<id>nightly-dependencies</id>
-			<activation>
-				<property>
-					<name>!release</name>
-				</property>
-			</activation>
-			<repositories>
-				<repository>
-					<name>Central Portal Snapshots</name>
-					<id>central-portal-snapshots</id>
-					<url>https://central.sonatype.com/repository/maven-snapshots/</url>
-					<releases>
-						<enabled>false</enabled>
-					</releases>
-					<snapshots>
-						<enabled>true</enabled>
-						<updatePolicy>always</updatePolicy>
-					</snapshots>
-				</repository>
-			</repositories>
 		</profile>
 
 		<profile>

--- a/eclipse/updatesite/pom.xml
+++ b/eclipse/updatesite/pom.xml
@@ -145,7 +145,7 @@
 						<plugin>
 							<groupId>org.apache.maven.plugins</groupId>
 							<artifactId>maven-checkstyle-plugin</artifactId>
-							<version>3.1.2</version>
+							<version>3.6.0</version>
 							<dependencies>
 								<dependency>
 									<groupId>com.puppycrawl.tools</groupId>

--- a/eclipse/updatesite/pom.xml
+++ b/eclipse/updatesite/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<groupId>org.palladiosimulator</groupId>
 		<artifactId>eclipse-parent</artifactId>
-		<version>0.8.11-SNAPSHOT</version>
+		<version>0.9.0-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 	<groupId>org.palladiosimulator</groupId>
 	<artifactId>eclipse-parent-updatesite</artifactId>
-	<version>0.8.11-SNAPSHOT</version>
+	<version>0.9.0-SNAPSHOT</version>
 	<name>${project.artifactId}</name>
 	<description>A common parent POM for all Eclipse Update Site builds of Palladio.</description>
 	<url>http://palladiosimulator.org</url>


### PR DESCRIPTION
- Increment version from 0.8.11-SNAPSHOT to 0.9.0-SNAPSHOT due to major changes to parent POMs hierarchy
- Bump versions of dependencies
- Migrate from OSSRH to Central Publisher Portal
- Consolidate commonalities into parent POM for better maintainability due to reduced duplication