### PR TITLE
Make updatesite Javadoc generation opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,5 @@ Then you would configure the `targetPlatform.relativePath` property in your root
 
 ## Update site / JavaDoc
 To define an update site, you have to create a POM with packaging type `eclipse-repository` and place a `category.xml` besides it. You can edit this file using the default Eclipse editors. The resulting update site will be placed in `target/repository`. The JavaDoc files will be placed in a `javadoc` folder inside the repository.
+
+The generation of update site JavaDoc is opt-in. Set the `generateJavaDocForUpdatesite` property for release builds, or whenever update site JavaDoc needs to be generated.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ Then you would configure the `targetPlatform.relativePath` property in your root
 ```
 
 ## Update site / JavaDoc
-To define an update site, you have to create a POM with packaging type `eclipse-repository` and place a `category.xml` besides it. You can edit this file using the default Eclipse editors. The resulting update site will be placed in `target/repository`. The JavaDoc files will be placed in a `javadoc` folder inside the repository.
+To define an update site, you have to create a POM with packaging type `eclipse-repository` and place a `category.xml` besides it. You can edit this file using the default Eclipse editors. The resulting update site will be placed in `target/repository`.
 
-The generation of update site JavaDoc is opt-in. Set the `generateJavaDocForUpdatesite` property for release builds, or whenever update site JavaDoc needs to be generated.
-Per-bundle JavaDoc is also opt-in. Set the `generateJavaDocPerBundle` property to trigger the generation of bundle-specific JavaDoc in each bundle's `target/javadoc` folder and package it as a JavaDoc archive (`-javadoc.jar`) in each bundle's `target` folder.
+JavaDoc generation is opt-in. Depending on your needs, you can enable it by setting the following properties:
+* `generateJavaDocForUpdatesite`: Generate update site JavaDoc (typically used for release builds). The JavaDoc files will be placed in `target/repository/javadoc`.
+* `generateJavaDocPerBundle`: Generate bundle-specific JavaDoc in each bundle's `target/javadoc` folder and package it as a JavaDoc archive (`-javadoc.jar`) in each bundle's `target` folder.

--- a/README.md
+++ b/README.md
@@ -66,3 +66,4 @@ Then you would configure the `targetPlatform.relativePath` property in your root
 To define an update site, you have to create a POM with packaging type `eclipse-repository` and place a `category.xml` besides it. You can edit this file using the default Eclipse editors. The resulting update site will be placed in `target/repository`. The JavaDoc files will be placed in a `javadoc` folder inside the repository.
 
 The generation of update site JavaDoc is opt-in. Set the `generateJavaDocForUpdatesite` property for release builds, or whenever update site JavaDoc needs to be generated.
+Per-bundle JavaDoc is also opt-in. Set the `generateJavaDocPerBundle` property to trigger the generation of bundle-specific JavaDoc in each bundle's `target/javadoc` folder and package it as a JavaDoc archive (`-javadoc.jar`) in each bundle's `target` folder.

--- a/eclipse/pom.xml
+++ b/eclipse/pom.xml
@@ -270,7 +270,7 @@
 									</goals>
 									<configuration>
 										<outputDirectory>xtend-gen</outputDirectory>
-										<javaSourceVersion>17</javaSourceVersion>
+										<javaSourceVersion>${java.version}</javaSourceVersion>
 									</configuration>
 								</execution>
 							</executions>

--- a/eclipse/pom.xml
+++ b/eclipse/pom.xml
@@ -40,25 +40,6 @@
 
 	<properties>
 		<tycho.version>2.7.5</tycho.version>
-		<javadoc.args>
-			-tag "generated:a:Generated class or method."
-			-tag "model:a:EMF model class or method."
-			-tag "ordered:a:Ordered collection."
-			-tag 'noimplement:a:Restriction:'
-			-tag 'noextend:a:Restriction:'
-			-tag 'noreference:a:Restriction:'
-			-tag 'noinstantiate:a:Restriction:'
-			-tag 'nooverride:a:Restriction:'
-			-tag 'category:a:Category:'
-			-link ${java.api.doc}
-			-link https://help.eclipse.org/2022-12/topic/org.eclipse.platform.doc.isv/reference/api
-			-link https://download.eclipse.org/modeling/emf/emf/javadoc/2.11/
-			-link https://download.eclipse.org/modeling/emft/mwe/javadoc/2.9/
-		</javadoc.args>
-		<!-- The property is meant to be overridden but still has to contain valid content, so we just repeat valid content. -->
-		<javadoc.additional.args>
-			-link ${java.api.doc}
-		</javadoc.additional.args>
 	</properties>
 	
 	<build>
@@ -196,7 +177,6 @@
 				<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 				<project.reporting.outputEncoding>${project.build.sourceEncoding}</project.reporting.outputEncoding>
 				<java.version>17</java.version>
-				<java.api.doc>https://docs.oracle.com/en/java/javase/17/docs/api/</java.api.doc>
 				<maven.compiler.target>${java.version}</maven.compiler.target>
 				<maven.compiler.source>${java.version}</maven.compiler.source>
 			</properties>

--- a/eclipse/updatesite/pom.xml
+++ b/eclipse/updatesite/pom.xml
@@ -130,6 +130,9 @@
 				<file>
 					<exists>category.xml</exists>
 				</file>
+				<property>
+					<name>generateJavaDocForUpdatesite</name>
+				</property>
 			</activation>
 			<build>
 				<plugins>

--- a/eclipse/updatesite/pom.xml
+++ b/eclipse/updatesite/pom.xml
@@ -15,6 +15,29 @@
 	<url>https://palladio-simulator.com</url>
 	<packaging>pom</packaging>
 
+	<properties>
+		<java.api.doc>https://docs.oracle.com/en/java/javase/17/docs/api/</java.api.doc>
+		<javadoc.args>
+			-tag "generated:a:Generated class or method."
+			-tag "model:a:EMF model class or method."
+			-tag "ordered:a:Ordered collection."
+			-tag 'noimplement:a:Restriction:'
+			-tag 'noextend:a:Restriction:'
+			-tag 'noreference:a:Restriction:'
+			-tag 'noinstantiate:a:Restriction:'
+			-tag 'nooverride:a:Restriction:'
+			-tag 'category:a:Category:'
+			-link ${java.api.doc}
+			-link https://help.eclipse.org/2022-12/topic/org.eclipse.platform.doc.isv/reference/api
+			-link https://download.eclipse.org/modeling/emf/emf/javadoc/2.11/
+			-link https://download.eclipse.org/modeling/emft/mwe/javadoc/2.9/
+		</javadoc.args>
+		<!-- The property is meant to be overridden but still has to contain valid content, so we just repeat valid content. -->
+		<javadoc.additional.args>
+			-link ${java.api.doc}
+		</javadoc.additional.args>
+	</properties>
+
 	<profiles>
 
 		<profile>

--- a/eclipse/updatesite/pom.xml
+++ b/eclipse/updatesite/pom.xml
@@ -16,7 +16,7 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<java.api.doc>https://docs.oracle.com/en/java/javase/17/docs/api/</java.api.doc>
+		<java.api.doc>https://docs.oracle.com/en/java/javase/${java.version}/docs/api/</java.api.doc>
 		<javadoc.args>
 			-tag "generated:a:Generated class or method."
 			-tag "model:a:EMF model class or method."

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.palladiosimulator</groupId>
 	<artifactId>parent-aggregator</artifactId>	
-	<version>6.0.0-SNAPSHOT</version>
+	<version>0.1.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<properties>


### PR DESCRIPTION
This pull request makes updatesite Javadoc generation opt-in so regular and nightly builds stay faster. The `generateJavaDocForUpdatesite` property should be set for release builds, or whenever updatesite Javadocs need to be generated.

It also centralizes the Java version configuration and updates the README to document when the property should be set.